### PR TITLE
Updated to return uris; permissive on input

### DIFF
--- a/bl_lookup/server.py
+++ b/bl_lookup/server.py
@@ -4,7 +4,7 @@ import urllib.parse
 from sanic import Sanic, response
 
 from bl_lookup.apidocs import bp as apidocs_blueprint
-from bl_lookup.bl import snake_case
+from bl_lookup.bl import key_case
 
 app = Sanic()
 app.config.ACCESS_LOG = False
@@ -23,7 +23,7 @@ async def lookup(request, concept, key):
     except KeyError:
         return response.text(f"No version '{version}' available\n", status=404)
 
-    concept = snake_case(concept)
+    concept = key_case(concept)
     try:
         properties = _data['geneology'][concept]
     except KeyError:
@@ -46,7 +46,7 @@ async def properties(request, concept):
     except KeyError:
         return response.text(f"No version '{version}' available\n", status=404)
 
-    concept = snake_case(concept)
+    concept = key_case(concept)
     try:
         props = _data['raw'][concept]
     except KeyError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bmt==0.2.2
+bmt==0.3.0
 biolinkml==1.6.0
 jinja2==2.11.2
 pyyaml==5.3.1


### PR DESCRIPTION
We want to start using uri's to represent node types and edge predicates in TRAPI messages, databases and so on.  That begins with the lookups.  

 With this pull request, calls to e.g. ancestors will return those ancestors as `biolink:ChemicalSubstance` or `biolink:related_to` rather than `chemical_substance` or `related_to`.

The input has been made more permissive.  The key is found by stripping any prefix (like biolink), then removing any _ or spaces, and lowercasing the whole thing.  The upshot is that `biolink:ChemicalSubstance` and `chemical substance` and various other forms will all match.  I don't think that there's a concern with collisions here.