### PR TITLE
fix error getting mixin ancestors

### DIFF
--- a/bl_lookup/bl.py
+++ b/bl_lookup/bl.py
@@ -109,13 +109,26 @@ class bmt_wrapper():
         elements = list(filter(lambda x: self.bmt.get_element(x) is not None, elements))
         return elements
 
+def get_all_mixins(bmt):
+    tk = bmt.bmt
+    all_elements = tk.get_all_elements()
+    mixins = []
+    for element in all_elements:
+        try:
+            if bmt.get_element(element)['mixin']:
+                mixins.append(element)
+        except:
+            pass
+    return mixins
+
+
 def generate_bl_map(url=None, version='latest'):
     """Generate map (dict) from BiolinkModel."""
     if url is None:
         url = models[version]
     bmt = bmt_wrapper(Toolkit(url))
     elements = bmt.get_descendants('related to') + bmt.get_descendants('association') + bmt.get_descendants('named thing') \
-        + ['named thing', 'related to', 'association']
+        + ['named thing', 'related to', 'association'] + get_all_mixins(bmt)
     geneology = {
         key_case(entity_type): {
             'ancestors': [bmt.name_to_uri(a) for a in bmt.get_ancestors(entity_type) if a != entity_type],

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -127,6 +127,14 @@ def test_lookup_ancestors_nodes():
         # But we should get a 404 for an unrecognized node type.
         call_unsuccessful_test('/bl/bad_substance/ancestors', param)
 
+def test_lookup_ancestors_mixin():
+    """In 2.x, genomic entity became a mixin, and looking up its ancestors began to fail"""
+    # setup some parameters
+    param = {'version': '2.1.0'}
+    # All these tests should return the same set of entities
+    expected = {'biolink:ThingWithTaxon'}
+    # With space
+    call_successful_test('/bl/genomic_entity/ancestors', expected, param)
 
 def test_resolve_predicate():
     param = {'version': version}


### PR DESCRIPTION
Reading the bmt was only pulling categories, predicates, and associations, but mixins are none of these.

So grabbed all the mixins.