### PR TITLE
2.2.1 update

### DIFF
--- a/bl_lookup/bl.py
+++ b/bl_lookup/bl.py
@@ -47,6 +47,7 @@ models = {
     '1.8.2': 'https://raw.githubusercontent.com/biolink/biolink-model/1.8.2/biolink-model.yaml',
     '2.0.2': 'https://raw.githubusercontent.com/biolink/biolink-model/2.0.2/biolink-model.yaml',
     '2.1.0': 'https://raw.githubusercontent.com/biolink/biolink-model/2.1.0/biolink-model.yaml',
+    '2.2.1': 'https://raw.githubusercontent.com/biolink/biolink-model/2.2.1/biolink-model.yaml',
     'latest': get_latest_bl_model_release_url()
 }
 

--- a/bl_lookup/templates/openapi.yml
+++ b/bl_lookup/templates/openapi.yml
@@ -3,8 +3,8 @@ info:
   title: Biolink Model Lookup
   description: 'The <a href="https://biolink.github.io/biolink-model/">Biolink Model</a> defines a set of common concepts for use in Translator. These include semantic types for entities, as well as the relations between them. These concepts are organized into an inheritance hierarchy capturing different granularities of description. Furthermore, each concept contains metadata relating the concept to ontologies.
 
-The Biolink Lookup Service provides a computational interface to the model, including access to previous versions. When the service is deployed, it queries the Biolink Github repository, and updates itself to access the latest version.'
-  version: '1.1.3'
+The Biolink Lookup Service provides a computational interface to the model, including access to previous versions. When the service is deployed, it queries the Biolink Github repository, and updates itself to access the latest supported (default) version.'
+  version: '1.1.4'
   contact:
     email: bizon@renci.org
     name: Chris Bizon

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='bl_lookup',
-    version='1.0.0',
+    version='1.1.4',
     author='Patrick Wang',
     author_email='patrick@covar.com',
     url='https://github.com/patrickkwang/bl_lookup',

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -111,7 +111,21 @@ def test_lookup_ancestors_nodes():
                                       "biolink:NamedThing",
                                       "biolink:Entity",
                                       "biolink:OntologyClass",
-                                      "biolink:PhysicalEssenceOrOccurrent"}}
+                                      "biolink:PhysicalEssenceOrOccurrent"},
+                            '2.1.0': {"biolink:Occurrent",
+                                      "biolink:BiologicalProcessOrActivity",
+                                      "biolink:BiologicalEntity",
+                                      "biolink:NamedThing",
+                                      "biolink:Entity",
+                                      "biolink:OntologyClass",
+                                      "biolink:PhysicalEssenceOrOccurrent"},
+                            '2.2.1': {"biolink:Occurrent",
+                                    "biolink:BiologicalProcessOrActivity",
+                                    "biolink:BiologicalEntity",
+                                    "biolink:NamedThing",
+                                    "biolink:Entity",
+                                    "biolink:OntologyClass",
+                                    "biolink:PhysicalEssenceOrOccurrent"}}
 
     for vers, expected in versions_and_results.items():
         param = {'version': vers}
@@ -157,7 +171,7 @@ def test_resolve_predicate():
 
 def test_RO_exact():
     expected = {"RO:0002506": {"identifier": "biolink:causes","label": "causes", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     '''If we have an RO that is an exact match, return an edge with that identfier'''
     call_successful_test('/resolve_predicate?predicate=RO:0002506', expected, param, use_set=False)
@@ -190,7 +204,7 @@ def test_inversion_narrow_matches():
 def test_inversion_symmetric():
     #RO:0002610 is correlated with.  It's symmetric so you can't invert it
     expected = {"RO:0002610": {"identifier": "biolink:correlated_with","label": "correlated with", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     '''If we have an RO that is an exact match, return an edge with that identfier'''
     call_successful_test('/resolve_predicate?predicate=RO:0002610', expected, param, use_set=False)
@@ -199,7 +213,7 @@ def test_inversion_symmetric():
 def test_exact_slot_URI_non_RO():
     '''If we have a curie that is not a RO, but is a slot uri, return it as an edge identifier'''
     expected = {"WIKIDATA_PROPERTY:P2293": {"identifier": "biolink:genetic_association", "label": "genetic association", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     '''If we have an RO that is an exact match, return an edge with that identfier'''
     call_successful_test('/resolve_predicate?predicate=WIKIDATA_PROPERTY:P2293', expected, param, use_set=False)
@@ -207,7 +221,7 @@ def test_exact_slot_URI_non_RO():
 def test_exact_mapping():
     '''If we have a curie that is a direct mapping, but not a slot uri, return the corresponding slot uri as an edge identifier'''
     expected = {"SEMMEDDB:PREVENTS": {"identifier": "biolink:prevents", "label": "prevents", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     '''If we have an RO that is an exact match, return an edge with that identfier'''
     call_successful_test('/resolve_predicate?predicate=SEMMEDDB:PREVENTS', expected, param, use_set=False)
@@ -216,7 +230,7 @@ def test_RO_sub():
     '''If we have a curie that is an RO, but is not a slot uri or a mapping, move to superclasses of the RO until we
     find one that we can map to BL. '''
     expected = {"RO:0003303": {"identifier": "biolink:causes", "label": "causes", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     '''If we have an RO that is an exact match, return an edge with that identfier'''
     call_successful_test('/resolve_predicate?predicate=RO:0003303', expected, param, use_set=False)
@@ -226,7 +240,7 @@ def test_RO_sub_2():
     find one that we can map to BL. '''
     #2049 is indirectly inhibits 2212 is its parent
     expected = {"RO:0002409": {"identifier": "biolink:process_negatively_regulates_process", "label": "process negatively regulates process", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     '''If we have an RO that is an exact match, return an edge with that identfier'''
     call_successful_test('/resolve_predicate?predicate=RO:0002409', expected, param, use_set=False)
@@ -235,7 +249,7 @@ def test_no_inverse():
     """CTD:affects_activity_of has an exact map and no inverse.  It shouldn't crash."""
     expected = {"CTD:affects_activity_of": {"identifier": "biolink:affects_activity_of",
                                "label": "affects activity of", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
     call_successful_test('/resolve_predicate?predicate=CTD:affects_activity_of', expected, param, use_set=False)
 
 
@@ -243,7 +257,7 @@ def test_RO_bad():
     '''RO isn't single rooted.  So it's easy to get to the follow our plan and not get anywhere.  In that case,
     we want to hit related_to by fiat.'''
     expected = {"RO:0002214": {"identifier": "biolink:related_to", "label": "related to", "inverted": False}}
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     '''If we have an RO that is an exact match, return an edge with that identfier'''
     call_successful_test('/resolve_predicate?predicate=RO:0002214', expected, param, use_set=False)
@@ -252,7 +266,7 @@ def test_lookup_ancestors_edges():
     """Looking up ancestors should be permissive, you should be able to look up by name with either space or
     underscores, and you should be able to look up by class uri. Also, we would like the lookup to be case insensitive"""
     # setup some parameters
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
     # All these tests should return the same set of entities
     expected = {'biolink:affects', 'biolink:related_to'}
     # With space
@@ -267,17 +281,14 @@ def test_lookup_ancestors_edges():
 
 def test_lookup_descendents_class():
     # setup some parameters
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
     # All these tests should return the same set of entities
-    expected = {
-        'biolink:Disease',
-        'biolink:PhenotypicFeature',
-        'biolink:DiseaseOrPhenotypicFeature',
-        'biolink:DiseaseOrPhenotypicFeatureExposure',
-        'biolink:DiseaseOrPhenotypicFeatureOutcome',
-        'biolink:BehavioralFeature',
-        'biolink:ClinicalFinding',
-    }
+    expected = {'biolink:BehavioralFeature',
+                 'biolink:ClinicalFinding',
+                 'biolink:Disease',
+                 'biolink:DiseaseOrPhenotypicFeature',
+                 'biolink:PhenotypicFeature'}
+
     # With space
     call_successful_test('/bl/disease or phenotypic feature/descendants', expected, param)
     # With underscores
@@ -294,7 +305,7 @@ def test_lookup_descendants_edges():
     """Looking up ancestors should be permissive, you should be able to look up by name with either space or
     underscores, and you should be able to look up by class uri. Also, we would like the lookup to be case insensitive"""
     # setup some parameters
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
     # All these tests should return the same set of entities
     expected = {'biolink:affects_expression_of', 'biolink:increases_expression_of', 'biolink:decreases_expression_of'}
     # With space
@@ -342,7 +353,7 @@ def test_lookup_with_commas():
 
 def test_lookup_lineage():
     # setup some parameters
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     # make a good request
     request, response = app.test_client.get('/bl/biological_process/lineage', params=param)
@@ -355,28 +366,18 @@ def test_lookup_lineage():
 
     # check the data.  This set works for version 1.4.0
     # Keeping these up to date is a nuisance.  What's the right thing to do?
-    expected = {
-                'biolink:Behavior',
-                'biolink:BehavioralExposure',
-                'biolink:BehavioralOutcome',
-                'biolink:BiologicalEntity',
-                'biolink:BiologicalProcess',
-                'biolink:BiologicalProcessOrActivity',
-                'biolink:Death',
-                'biolink:Entity',
-                'biolink:MortalityOutcome',
-                'biolink:NamedThing',
-                'biolink:Occurrent',
-                'biolink:OntologyClass',
-                'biolink:PathologicalProcess',
-                'biolink:PathologicalProcessExposure',
-                'biolink:PathologicalProcessOutcome',
-                'biolink:Pathway',
-                'biolink:PhysicalEssenceOrOccurrent',
-                'biolink:PhysiologicalProcess',
-                'biolink:SocioeconomicExposure',
-                'biolink:SocioeconomicOutcome'
-    }
+    expected = {'biolink:Behavior',
+                 'biolink:BiologicalEntity',
+                 'biolink:BiologicalProcess',
+                 'biolink:BiologicalProcessOrActivity',
+                 'biolink:Entity',
+                 'biolink:NamedThing',
+                 'biolink:Occurrent',
+                 'biolink:OntologyClass',
+                 'biolink:PathologicalProcess',
+                 'biolink:Pathway',
+                 'biolink:PhysicalEssenceOrOccurrent',
+                 'biolink:PhysiologicalProcess'}
 
     assert set(ret) == expected
 
@@ -389,8 +390,7 @@ def test_lookup_lineage():
 
 def call_uri_lookup(uri, expected_mapping):
     # setup some parameters
-    # works for latest = 1.4.0
-    param = {'version': '1.8.2'}
+    param = {'version': '2.2.1'}
 
     # make a good request
     request, response = app.test_client.get(f'/uri_lookup/{uri}', params=param)
@@ -459,4 +459,4 @@ def test_versions():
     ret = json.loads(response.body)
 
     # check the data
-    assert(len(ret) == 11 and 'latest' in ret)
+    assert(len(ret) == 12 and 'latest' in ret)


### PR DESCRIPTION
couple of tweaks to insure that bl model version 2.2.1 can be selected and the tests work. this is to support data services (predicate resolution).