### PR TITLE
added related_to as a failsafe

### DIFF
--- a/bl_lookup/bl.py
+++ b/bl_lookup/bl.py
@@ -47,6 +47,7 @@ models = {
     '1.8.2': 'https://raw.githubusercontent.com/biolink/biolink-model/1.8.2/biolink-model.yaml',
     '2.0.2': 'https://raw.githubusercontent.com/biolink/biolink-model/2.0.2/biolink-model.yaml',
     '2.1.0': 'https://raw.githubusercontent.com/biolink/biolink-model/2.1.0/biolink-model.yaml',
+    '2.2.3': 'https://raw.githubusercontent.com/biolink/biolink-model/2.2.3/biolink-model.yaml',
     'latest': get_latest_bl_model_release_url()
 }
 

--- a/bl_lookup/server.py
+++ b/bl_lookup/server.py
@@ -208,8 +208,12 @@ async def resolve(request):
                         props = concepts['raw'][newconcept]
                         inverted = True
         except KeyError:
+            result[predicate] = {
+                'identifier': 'biolink:related_to',
+                'label': 'related to',
+                'inverted': False
+            }
             continue
-            # return response.text(f"No concept properties for '{concept}'\n", status=404)
 
         # did we get everything
         if props:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -153,7 +153,25 @@ def test_resolve_predicate():
     # check the data
     assert (ret == expected)
 
-    call_unsuccessful_test('/resolve_predicate?predicate=couldbeanything', param)
+    #No no, this should return related_to, see "test_resolve_crap_predicate"
+    #call_unsuccessful_test('/resolve_predicate?predicate=couldbeanything', param)
+
+def test_resolve_crap_predicate():
+    """No matter what you send in, it's a related to"""
+    param = {'version': '2.2.3'}
+    expected = {'GARBAGE:NOTHING': {'identifier': 'biolink:related_to', 'label': 'related to', 'inverted': False}}
+
+    # make a good request
+    request, response = app.test_client.get('/resolve_predicate?predicate=GARBAGE:NOTHING', params=param)
+
+    # was the request successful
+    assert (response.status_code == 200)
+
+    # convert the response to a json object
+    ret = json.loads(response.body)
+
+    # check the data
+    assert (ret == expected)
 
 def test_RO_exact():
     expected = {"RO:0002506": {"identifier": "biolink:causes","label": "causes", "inverted": False}}


### PR DESCRIPTION
No matter what, resolve_predicates will backstop on related_to.