### PR TITLE
fixes 500

### DIFF
--- a/bl_lookup/bl.py
+++ b/bl_lookup/bl.py
@@ -146,6 +146,14 @@ class bmt_wrapper():
             del element['local_names']
         if 'slot_usage' in element:
             del element['slot_usage']
+        #Annotations are also not JSON serializable.  The current structure is:
+        # 'annotations': annotations={'biolink:canonical_predicate':
+        # Annotation(tag='biolink:canonical_predicate', value='True', extensions={}, annotations={})}
+        # And we want to turn that into "Tag":"Value"
+        if 'annotations' in element:
+            for k,v in element['annotations'].items():
+                element[v['tag']] = v['value']
+            del element['annotations']
         return element
 
     def get_descendants(self, name):

--- a/bl_lookup/server.py
+++ b/bl_lookup/server.py
@@ -198,8 +198,8 @@ async def resolve(request):
                     #Can't invert something with no inverse.
                     inverted = False
                 else:
-                    annots = props['annotations']
-                    if (annots is not None) and ('biolink:canonical_predicate' in annots) and annots['biolink:canonical_predicate'].value:
+                    #annots = props['annotations']
+                    if 'biolink:canonical_predicate' in props and props['biolink:canonical_predicate'].upper() == 'TRUE':
                         #this is the canonical direction, all good
                         inverted = False
                     else:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -369,6 +369,17 @@ def test_lookup_with_commas():
         assert (response.status_code == 200)
 
 
+def test_lookup_related_to():
+    # setup some parameters
+    param = {'version': '2.2.5'}
+
+    # make a good request
+    #request, response = app.test_client.get('/bl/related_to', params=param)
+    request, response = app.test_client.get('/bl/acts_upstream_of', params=param)
+
+    # was the request successful
+    assert(response.status_code == 200)
+
 def test_lookup_lineage():
     # setup some parameters
     param = {'version': '2.2.3'}
@@ -458,7 +469,7 @@ def test_properties():
     ret = json.loads(response.body)
 
     # check the data
-    assert(len(ret) == 54 and ret['id_prefixes'][0] == 'PUBCHEM.COMPOUND' and ret['class_uri'] == 'biolink:SmallMolecule' and 'is metabolite' in ret['slots'])
+    assert(len(ret) == 53 and ret['id_prefixes'][0] == 'PUBCHEM.COMPOUND' and ret['class_uri'] == 'biolink:SmallMolecule' and 'is metabolite' in ret['slots'])
 
     # make a bad request
     request, response = app.test_client.get('/bl/bad_substance', params=param)


### PR DESCRIPTION
Fixes #51 

The problem would occur with any predicate that had a biolink:canonical annotation.  The annotations as defined by BMT were passing through to the response, but could not be serialized.