### PR TITLE
lib updates test fix, bmt upgrades

### DIFF
--- a/bl_lookup/bl.py
+++ b/bl_lookup/bl.py
@@ -9,7 +9,7 @@ from jsonasobj import as_dict
 default_version = os.environ.get('DEFAULT_VERSION', "2.2.3")
 
 # do not load these versions
-skip_versions = ['v1.0.0', 'v1.1.0', 'v1.1.1', 'v1.2.0', 'v1.3.0', 'v2.4.2-alpha-qualifiers']
+skip_versions = ['v1.0.0', 'v1.1.0', 'v1.1.1', 'v1.2.0', 'v1.3.0', 'v2.4.2-alpha-qualifiers', 'deprecated-predicates']
 
 
 def get_latest_bl_model_release_url() -> str:

--- a/bl_lookup/templates/openapi.yml
+++ b/bl_lookup/templates/openapi.yml
@@ -4,7 +4,7 @@ info:
   description: 'The <a href="https://biolink.github.io/biolink-model/">Biolink Model</a> defines a set of common concepts for use in Translator. These include semantic types for entities, as well as the relations between them. These concepts are organized into an inheritance hierarchy capturing different granularities of description. Furthermore, each concept contains metadata relating the concept to ontologies.
 
 The Biolink Lookup Service provides a computational interface to the model, including access to previous versions. When the service is deployed, it queries the Biolink Github repository, and updates itself to access the latest supported (default) version.'
-  version: '1.1.12'
+  version: '1.1.13'
   contact:
     email: bizon@renci.org
     name: Chris Bizon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 #linkml and black just here to set versions.  Once bmt is fixed, this can go away
-linkml==1.1.17
+linkml==1.3.2
+linkml-dataops==0.1.0
+linkml-runtime==1.3.2
 black<=21.12b0
 #Real stuff starts here
-bmt==0.8.1
+bmt==0.8.11
 jinja2==3.0.1
 pyyaml==5.1
-requests==2.26.0
 sanic==20.9.1
 swagger_ui_bundle==0.0.8
 pytest==6.2.4

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -145,7 +145,7 @@ def test_lookup_ancestors_mixin():
 def test_resolve_predicate():
     param = {'version': version}
     expected = {'SEMMEDDB:CAUSES': {'identifier': 'biolink:causes', 'label': 'causes', 'inverted': False},
-                'SEMMEDDB:CAUSES': {'identifier': 'biolink:causes_by', 'label': 'caused by', 'inverted': True},
+                'SEMMEDDB:CAUSES': {'identifier': 'biolink:caused_by', 'label': 'caused by', 'inverted': True},
                 'RO:0000052': {'identifier': 'biolink:related_to', 'label': 'related to', 'inverted': False}}
 
     # make a good request

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -145,6 +145,7 @@ def test_lookup_ancestors_mixin():
 def test_resolve_predicate():
     param = {'version': version}
     expected = {'SEMMEDDB:CAUSES': {'identifier': 'biolink:causes', 'label': 'causes', 'inverted': False},
+                'SEMMEDDB:CAUSES': {'identifier': 'biolink:causes_by', 'label': 'caused by', 'inverted': True},
                 'RO:0000052': {'identifier': 'biolink:related_to', 'label': 'related to', 'inverted': False}}
 
     # make a good request
@@ -471,4 +472,4 @@ def test_versions():
     ret = json.loads(response.body)
 
     # check the data
-    assert(len(ret) == 39 and 'latest' in ret)
+    assert(len(ret) == 45 and 'latest' in ret)


### PR DESCRIPTION
Bumps the following libs 
```
linkml                        1.3.2
linkml-dataops                0.1.0
linkml-runtime                1.3.2
```
as per (https://github.com/biolink/biolink-model-toolkit/issues/88) , 
Fixes tests.